### PR TITLE
Use `candidates-files` instead of `candidates-process` in `helm-source-dictionary`.

### DIFF
--- a/helm-dictionary.el
+++ b/helm-dictionary.el
@@ -116,7 +116,7 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl))
+(require 'cl-lib)
 (require 'helm)
 (require 'browse-url)
 
@@ -189,28 +189,26 @@ values that are admissible for the `browse-url-browser-function'."
 
 (defun helm-dictionary-transformer (candidates)
   "Formats entries retrieved from the data base."
-  (loop for i in candidates
-        with entry and l1terms and l2terms and width
-        if (or (string-match "\\`#" i)
-               (not (string-match " :: ?" i)))
-          append (list)
-        else
-          do     (setf entry (split-string i " :: ?"))
-          and do (setf l1terms (split-string (car entry) " | "))
-          and do (setf l2terms (split-string (cadr entry) " | "))
-          and do (setf width   (with-helm-window (window-width)))
-          and append
-          (loop for l1term in l1terms
-                for l2term in l2terms
-                if (or (string-match helm-pattern l1term)
-                       (string-match helm-pattern l2term))
-                collect
-                (cons 
-                  (concat
-                    (truncate-string-to-width l1term (- (/ width 2) 1) 0 ?\s)
-                    " "
-                    (truncate-string-to-width l2term (- (/ width 2) 1) 0 ?\s))
-                  (cons l1term l2term)))))
+  (cl-loop for i in candidates
+           with entry and l1terms and l2terms
+           and width = (with-helm-window (window-width))
+           unless (or (string-match "\\`#" i)
+                      (not (string-match " :: ?" i)))
+           do (progn (setq entry (split-string i " :: ?"))
+                     (setq l1terms (split-string (car entry) " | "))
+                     (setq l2terms (split-string (cadr entry) " | ")))
+           and append
+           (cl-loop for l1term in l1terms
+                    for l2term in l2terms
+                    if (or (string-match helm-pattern l1term)
+                           (string-match helm-pattern l2term))
+                    collect
+                    (cons 
+                     (concat
+                      (truncate-string-to-width l1term (- (/ width 2) 1) 0 ?\s)
+                      " "
+                      (truncate-string-to-width l2term (- (/ width 2) 1) 0 ?\s))
+                     (cons l1term l2term)))))
 
 
 (defun helm-dictionary-insert-l1term (entry)


### PR DESCRIPTION
This implements Thierry's suggestion to use `candidates-file` instead of `candidates-process` in `helm-source-dictionary` (see issue #9).  Benefits:
- Simpler code and thus perhaps more robust.
- Handles missing dictionary (fixes issue #7).
- No dependency on grep (good for Windows users, I suppose).
- Standard Emacs search semantics (searches are case-insensitive unless there is an upper-case letter in the search term).
